### PR TITLE
Add MVP counters and result overlay to store GUI

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+      <body suppressHydrationWarning className={`${geistSans.variable} ${geistMono.variable}`}>
         {children}
       </body>
     </html>

--- a/src/components/StoreGuiView.tsx
+++ b/src/components/StoreGuiView.tsx
@@ -29,12 +29,9 @@ const makePersonSprite = (src: string) => {
 };
 
 // ★SPRITE: place person by "foot" position (x,y = where feet touch the floor)
-// We treat inputs as "footX/footY". With anchor(0.5,1.0), the sprite's top is y - height,
-// so we set sprite.y = footY + height to match older "center-based" coordinates.
 const placePerson = (sp: any, footX: number, footY: number) => {
   sp.x = footX;
-  const h = (typeof sp.height === "number" && isFinite(sp.height)) ? sp.height : 0;
-  sp.y = footY + h;
+  sp.y = footY;
 };
 
 

--- a/src/components/StoreGuiView.tsx
+++ b/src/components/StoreGuiView.tsx
@@ -604,8 +604,8 @@ export default function StoreGuiView() {
       const localShelfStock = new Map<string, number>();
       for (const sid of shelfIds) localShelfStock.set(sid, shelfStock?.[sid] ?? 0);
 
-      let staffDots1: PIXI.Graphics[] = [];
-      let staffDots2: PIXI.Graphics[] = [];
+      let staffDots1: PIXI.Sprite[] = [];
+      let staffDots2: PIXI.Sprite[] = [];
 
       const clearContainer = (c: PIXI.Container) => {
         while (c.children.length) {
@@ -614,8 +614,8 @@ export default function StoreGuiView() {
         }
       };
 
-      const drawStaffDots = (counter: Rect, staffN: number): PIXI.Graphics[] => {
-        const dots: PIXI.Graphics[] = [];
+      const drawStaffDots = (counter: Rect, staffN: number): PIXI.Sprite[] => {
+        const dots: PIXI.Sprite[] = [];
         const staffR = 8;
         const staffGap = 18;
         const baseX = centerOf(counter).x - ((staffN - 1) * staffGap) / 2;
@@ -1064,7 +1064,7 @@ export default function StoreGuiView() {
       // ---- staff busy ----
       let tAccum = 0;
 
-      const setStaffIdle = (dots: PIXI.Graphics[]) => {
+      const setStaffIdle = (dots: PIXI.Sprite[]) => {
         for (const d of dots) {
           const bx = (d as any).__baseX ?? d.x;
           const by = (d as any).__baseY ?? d.y;
@@ -1075,7 +1075,7 @@ export default function StoreGuiView() {
         }
       };
 
-      const setStaffBusy = (dots: PIXI.Graphics[], phaseOffset: number) => {
+      const setStaffBusy = (dots: PIXI.Sprite[], phaseOffset: number) => {
         for (let i = 0; i < dots.length; i++) {
           const d = dots[i];
           const bx = (d as any).__baseX ?? d.x;


### PR DESCRIPTION
## Summary
- track per-run MVP counts for sales, spawns, served customers, and losses
- reset and publish MVP results when a GUI run completes
- render staff sprites on the staff layer and show a dismissible MVP results overlay

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954c0c6bae08333b9e18d648a564bc7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-run MVP analytics tracking sales and customers (spawned/served/lost) with a dismissible results panel.
* **UI**
  * Staff and actor visuals moved to sprite-based rendering for improved appearance and consistent scene drawing.
* **Bug Fix**
  * Reduced hydration-related warnings during page load.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->